### PR TITLE
Build WhatsApp contact widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Core-Zodiac
-couple of Ai tools or testing after building
+
+A lightweight static demo for a WhatsApp contact widget.
+
+## WhatsApp widget
+
+The widget includes:
+
+- A floating WhatsApp launcher.
+- A chat-style support card with availability text.
+- Suggested quick replies that populate the message field.
+- A direct `wa.me` click-to-chat URL with an encoded prefilled message.
+- Responsive styling for desktop and mobile layouts.
+
+## Run locally
+
+```bash
+npm run start
+```
+
+Then open <http://localhost:4173>.
+
+## Configure
+
+Update `businessPhoneNumber` in `src/main.js` with the WhatsApp Business phone number in international format without `+`, spaces, or dashes.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="A polished WhatsApp support widget that helps visitors start a chat quickly."
+    />
+    <title>Core Zodiac WhatsApp Widget</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="hero" aria-labelledby="hero-title">
+        <p class="eyebrow">Core Zodiac</p>
+        <h1 id="hero-title">Help customers reach you in one tap.</h1>
+        <p class="hero-copy">
+          This demo page includes a responsive WhatsApp widget with quick replies,
+          an availability card, and an accessible floating launcher.
+        </p>
+        <a class="hero-cta" href="#whatsapp-widget">Try the widget</a>
+      </section>
+    </main>
+
+    <aside class="whatsapp-widget" id="whatsapp-widget" aria-live="polite">
+      <section class="chat-card" id="chat-card" aria-labelledby="chat-card-title">
+        <header class="chat-header">
+          <div class="agent-avatar" aria-hidden="true">CZ</div>
+          <div>
+            <h2 id="chat-card-title">Chat with Core Zodiac</h2>
+            <p>Typically replies in a few minutes</p>
+          </div>
+          <button class="icon-button" id="close-chat" type="button" aria-label="Close WhatsApp widget">
+            &times;
+          </button>
+        </header>
+
+        <div class="chat-body">
+          <div class="message inbound">
+            Hi! 👋 Tell us what you need and we’ll continue the conversation on WhatsApp.
+          </div>
+          <div class="quick-replies" aria-label="Suggested WhatsApp messages">
+            <button type="button" data-message="Hello Core Zodiac, I need help choosing a service.">
+              I need help choosing a service
+            </button>
+            <button type="button" data-message="Hello Core Zodiac, I would like to book a consultation.">
+              Book a consultation
+            </button>
+            <button type="button" data-message="Hello Core Zodiac, can you share pricing details?">
+              Share pricing details
+            </button>
+          </div>
+          <label class="message-label" for="custom-message">Your message</label>
+          <textarea
+            id="custom-message"
+            rows="3"
+            placeholder="Write your message..."
+          >Hello Core Zodiac, I would like to learn more.</textarea>
+          <a class="whatsapp-link" id="whatsapp-link" href="https://wa.me/15551234567?text=Hello%20Core%20Zodiac%2C%20I%20would%20like%20to%20learn%20more." target="_blank" rel="noopener noreferrer">
+            Continue on WhatsApp
+          </a>
+        </div>
+      </section>
+
+      <button class="launcher" id="open-chat" type="button" aria-expanded="true" aria-controls="chat-card">
+        <span class="launcher-icon" aria-hidden="true">☎</span>
+        <span>WhatsApp us</span>
+      </button>
+    </aside>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "core-zodiac-whatsapp-widget",
+  "version": "1.0.0",
+  "description": "A lightweight static WhatsApp contact widget demo.",
+  "private": true,
+  "scripts": {
+    "start": "python3 -m http.server 4173",
+    "check": "python3 - <<'PY'\nfrom pathlib import Path\nfor path in ['index.html', 'src/styles.css', 'src/main.js']:\n    data = Path(path).read_text()\n    assert data.strip(), f'{path} is empty'\nprint('Static widget files are present.')\nPY"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,35 @@
+const businessPhoneNumber = "15551234567";
+const chatCard = document.querySelector("#chat-card");
+const openButton = document.querySelector("#open-chat");
+const closeButton = document.querySelector("#close-chat");
+const messageInput = document.querySelector("#custom-message");
+const whatsappLink = document.querySelector("#whatsapp-link");
+const quickReplies = document.querySelectorAll("[data-message]");
+
+function buildWhatsAppUrl(message) {
+  const encodedMessage = encodeURIComponent(message.trim());
+  return `https://wa.me/${businessPhoneNumber}?text=${encodedMessage}`;
+}
+
+function syncWhatsAppLink() {
+  whatsappLink.href = buildWhatsAppUrl(messageInput.value);
+}
+
+function setWidgetOpen(isOpen) {
+  chatCard.classList.toggle("is-hidden", !isOpen);
+  openButton.setAttribute("aria-expanded", String(isOpen));
+}
+
+quickReplies.forEach((reply) => {
+  reply.addEventListener("click", () => {
+    messageInput.value = reply.dataset.message;
+    syncWhatsAppLink();
+    messageInput.focus();
+  });
+});
+
+messageInput.addEventListener("input", syncWhatsAppLink);
+openButton.addEventListener("click", () => setWidgetOpen(true));
+closeButton.addEventListener("click", () => setWidgetOpen(false));
+
+syncWhatsAppLink();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,290 @@
+:root {
+  color: #10231c;
+  background: #f5fbf8;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  --whatsapp: #25d366;
+  --whatsapp-dark: #128c7e;
+  --ink: #10231c;
+  --muted: #63746d;
+  --card: #ffffff;
+  --shadow: 0 24px 70px rgba(16, 35, 28, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(37, 211, 102, 0.22), transparent 30rem),
+    linear-gradient(135deg, #f7fff9 0%, #e8f5ee 48%, #daf0e5 100%);
+}
+
+.page-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.hero {
+  width: min(44rem, 100%);
+  padding: 4rem;
+  border: 1px solid rgba(18, 140, 126, 0.12);
+  border-radius: 2rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 20px 80px rgba(18, 140, 126, 0.16);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--whatsapp-dark);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 7vw, 5.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
+}
+
+.hero-copy {
+  max-width: 34rem;
+  margin: 1.5rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.hero-cta,
+.whatsapp-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.25rem;
+  padding: 0.85rem 1.35rem;
+  border-radius: 999px;
+  background: var(--whatsapp);
+  color: #062015;
+  font-weight: 800;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.hero-cta:hover,
+.whatsapp-link:hover,
+.launcher:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(37, 211, 102, 0.34);
+}
+
+.whatsapp-widget {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 20;
+  display: grid;
+  justify-items: end;
+  gap: 1rem;
+}
+
+.chat-card {
+  width: min(24rem, calc(100vw - 2rem));
+  overflow: hidden;
+  border: 1px solid rgba(18, 140, 126, 0.16);
+  border-radius: 1.4rem;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  transform-origin: bottom right;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    visibility 180ms ease;
+}
+
+.chat-card.is-hidden {
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(0.75rem) scale(0.96);
+}
+
+.chat-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 1rem;
+  background: linear-gradient(135deg, var(--whatsapp-dark), #075e54);
+  color: white;
+}
+
+.agent-avatar {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  border-radius: 50%;
+  background: var(--whatsapp);
+  color: #062015;
+  font-weight: 900;
+}
+
+.chat-header h2,
+.chat-header p {
+  margin: 0;
+}
+
+.chat-header h2 {
+  font-size: 1rem;
+}
+
+.chat-header p {
+  opacity: 0.82;
+  font-size: 0.83rem;
+}
+
+.icon-button,
+.launcher,
+.quick-replies button {
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.icon-button {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.16);
+  color: white;
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.chat-body {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  background: #efeae2;
+}
+
+.message {
+  max-width: 88%;
+  padding: 0.8rem 0.9rem;
+  border-radius: 1rem 1rem 1rem 0.25rem;
+  background: white;
+  box-shadow: 0 8px 18px rgba(16, 35, 28, 0.08);
+  line-height: 1.5;
+}
+
+.quick-replies {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.quick-replies button {
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(18, 140, 126, 0.2);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--whatsapp-dark);
+  font-weight: 700;
+  text-align: left;
+}
+
+.quick-replies button:hover,
+.quick-replies button:focus-visible {
+  outline: none;
+  border-color: var(--whatsapp);
+  background: #f0fff5;
+}
+
+.message-label {
+  color: var(--ink);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid rgba(18, 140, 126, 0.22);
+  border-radius: 1rem;
+  padding: 0.85rem;
+  color: var(--ink);
+  font: inherit;
+}
+
+textarea:focus {
+  outline: 3px solid rgba(37, 211, 102, 0.28);
+  border-color: var(--whatsapp-dark);
+}
+
+.whatsapp-link {
+  width: 100%;
+  border-radius: 1rem;
+}
+
+.launcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 3.7rem;
+  padding: 0.8rem 1.25rem 0.8rem 0.8rem;
+  border-radius: 999px;
+  background: #10231c;
+  color: white;
+  box-shadow: var(--shadow);
+  font-weight: 900;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.launcher-icon {
+  display: grid;
+  width: 2.45rem;
+  height: 2.45rem;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--whatsapp);
+  color: #062015;
+}
+
+@media (max-width: 42rem) {
+  .page-shell {
+    align-items: start;
+    padding: 1rem;
+  }
+
+  .hero {
+    padding: 2.25rem 1.25rem;
+  }
+
+  .whatsapp-widget {
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+  }
+
+  .chat-card,
+  .launcher {
+    width: 100%;
+  }
+
+  .launcher {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, accessible WhatsApp contact widget so visitors can start a chat with a prefilled message in one tap. 
- Offer quick-reply templates and an editable message field that generate properly encoded `wa.me` click-to-chat links. 
- Deliver a small static demo that can be run locally without a JS framework.

### Description
- Added a static landing page with the widget markup in `index.html` including a floating launcher, chat card, quick replies, message textarea, and `Continue on WhatsApp` CTA. 
- Implemented widget behavior in `src/main.js` with `businessPhoneNumber`, `buildWhatsAppUrl()`, `syncWhatsAppLink()`, and `setWidgetOpen()` to populate and encode `https://wa.me/<number>?text=` links and toggle visibility. 
- Added responsive styling for the hero, chat card, quick replies, and launcher in `src/styles.css`. 
- Added `package.json` scripts for `start` (static server) and `check` (presence smoke-check) and updated `README.md` with run and configuration instructions.

### Testing
- Ran `npm run check` (Python presence assertions) which completed successfully. 
- Started the static server with `npm run start` and ran a urllib smoke test against `http://127.0.0.1:4173/` which verified the page contains the widget markup. 
- Attempted `npm install` but it failed due to a `403` from the npm registry (environment/network restriction). 
- Attempted to use Playwright for screenshot/browser automation but it was unavailable in the environment (no browser/runtime installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc35e186c8331aa006ae014cc3b5b)